### PR TITLE
Reverted to Android SDK 25

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "fr.neamar.lolgamedata"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 25""
         versionCode 72
         versionName "2.16.2"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'newrelic'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 25
 
     defaultConfig {
         applicationId "fr.neamar.lolgamedata"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 25
         versionCode 72
         versionName "2.16.2"
 
@@ -49,10 +48,10 @@ dependencies {
 
     // Support old Android, push notifications and cardviews
     compile 'com.google.android.gms:play-services-gcm:11.4.2'
-    compile 'com.android.support:support-v4:26.1.0'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support:cardview-v7:26.1.0'
+    compile 'com.android.support:support-v4:25.4.0'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:design:25.4.0'
+    compile 'com.android.support:cardview-v7:25.4.0'
 
     // HTTP request
     compile 'com.mcxiaoke.volley:library-aar:1.0.0'

--- a/app/src/main/java/fr/neamar/lolgamedata/GameActivity.java
+++ b/app/src/main/java/fr/neamar/lolgamedata/GameActivity.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import fr.neamar.lolgamedata.adapter.SectionsPagerAdapter;
 import fr.neamar.lolgamedata.pojo.Account;
 import fr.neamar.lolgamedata.pojo.Game;
-import fr.neamar.lolgamedata.service.RegistrationIntentService;
 import fr.neamar.lolgamedata.volley.NoCacheRetryJsonRequest;
 
 public class GameActivity extends SnackBarActivity {
@@ -171,11 +170,6 @@ public class GameActivity extends SnackBarActivity {
         if (savedInstanceState == null || !savedInstanceState.containsKey("game")) {
             loadCurrentGame(account.summonerName, account.region);
         }
-
-        // Register for push notifications, send token again in case it changed
-        Intent intent = new Intent(this, RegistrationIntentService.class);
-        Log.i(TAG, "Starting Service");
-        startService(intent);
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/lolgamedata/LolApplication.java
+++ b/app/src/main/java/fr/neamar/lolgamedata/LolApplication.java
@@ -1,9 +1,11 @@
 package fr.neamar.lolgamedata;
 
 import android.app.Application;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Handler;
+import android.os.StrictMode;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -18,6 +20,7 @@ import org.json.JSONArray;
 import java.util.List;
 
 import fr.neamar.lolgamedata.pojo.Account;
+import fr.neamar.lolgamedata.service.RegistrationIntentService;
 
 public class LolApplication extends Application {
     private static final String TAG = "LolApplication";
@@ -44,7 +47,6 @@ public class LolApplication extends Application {
         ImageLoader.getInstance().init(config);
 
         if (BuildConfig.DEBUG) {
-            /*
             StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
                     .detectAll()
                     .penaltyLog()
@@ -54,7 +56,6 @@ public class LolApplication extends Application {
                     .penaltyLog()
                     .penaltyDeath()
                     .build());
-            */
         }
 
         // Tracking initialization
@@ -67,7 +68,10 @@ public class LolApplication extends Application {
         Handler handler = new Handler();
         handler.post(r);
 
-
+        // Register for push notifications, send token again in case it changed
+        Intent intent = new Intent(this, RegistrationIntentService.class);
+        Log.i(TAG, "Starting Service");
+        startService(intent);
     }
 
     public MixpanelAPI getMixpanel() {

--- a/app/src/main/java/fr/neamar/lolgamedata/pojo/Game.java
+++ b/app/src/main/java/fr/neamar/lolgamedata/pojo/Game.java
@@ -24,7 +24,7 @@ public class Game implements Serializable {
     public Game(JSONObject game, String region, Account associatedAccount, boolean useRelativeTeamColor) throws JSONException {
         gameId = game.getLong("game_id");
         mapId = game.getInt("map_id");
-        queue = game.getInt("queue");
+        queue = game.optInt("queue", 0);
 
         startTime = new Date(game.optLong("game_start_time", new Date().getTime()));
         this.associatedAccount = associatedAccount;

--- a/app/src/main/java/fr/neamar/lolgamedata/service/NotificationService.java
+++ b/app/src/main/java/fr/neamar/lolgamedata/service/NotificationService.java
@@ -35,8 +35,11 @@ public class NotificationService extends GcmListenerService {
      */
     @Override
     public void onMessageReceived(String from, Bundle data) {
+        Log.e("WTF", "Bundle: " + data.toString());
+        Log.e("WTF", "GameID:" + data.getString("gameId"));
+
         if (data.containsKey("gameId")) {
-            long gameId = data.getLong("gameId");
+            long gameId = Long.parseLong(data.getString("gameId"));
             String gameMode = data.getString("gameMode");
             String summonerName = data.getString("summonerName");
             String region = data.getString("region");
@@ -95,7 +98,10 @@ public class NotificationService extends GcmListenerService {
         NotificationManager notificationManager = getNotificationManager();
         if (prefs.getBoolean("notifications_new_game", true)) {
             try {
+                Log.e("WTF", "Builing...");
                 notificationManager.notify(Long.toString(gameId).hashCode(), notificationBuilder.build());
+                Log.e("WTF", "Built!");
+
             } catch (RuntimeException e) {
                 // Most likely, the ringtone doesn't exist anymore. Use system default
                 // (seems to be a bug in Android 6.0)

--- a/circle.yml
+++ b/circle.yml
@@ -19,16 +19,14 @@ test:
     #    parallel: true
   override:
    # Lint the project
-   # Retry command automatically cause Gradle is super brittle
-    - ./gradlew lint --console=plain || ./gradlew lint --console=plain
-    # Run tests, build the apk, and build the test apk for running
-    # the espresso tests
-    - ./gradlew test assembleDebug assembleDebugAndroidTest --console=plain || ./gradlew test assembleDebug assembleDebugAndroidTest --console=plain
+    - ./gradlew lint --console=plain
+    # Run tests, build the apk, and build the test apk for running the espresso tests
+    - ./gradlew test assembleDebug assembleDebugAndroidTest --console=plain
     # TESTS DISABLED FOR NOW. CAN'T GET THEM TO WORK IN THE CI. They will run on a real device or Firebase.
     # # wait for the emulator to have booted
     # - circle-android wait-for-boot
     # # Run espresso tests
-    # - ./gradlew connectedAndroidTest --console=plain || ./gradlew connectedAndroidTest --console=plain
+    # - ./gradlew connectedAndroidTest --console=plain
   post:
     - cp -r app/build/outputs $CIRCLE_ARTIFACTS || true
     - mkdir $CIRCLE_ARTIFACTS/reports

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     GRADLE_OPTS: -Dorg.gradle.daemon=true -Dorg.gradle.jvmargs=-Xmx2048M
 dependencies:
   pre:
-   - echo y | android update sdk --no-ui --all --filter "android-26","build-tools-26.0.0","extra-android-m2repository","google-services"
+   - echo y | android update sdk --no-ui --all --filter "android-25","build-tools-26.0.0","extra-android-m2repository","google-services"
    - ./gradlew:
        background: true
 checkout:


### PR DESCRIPTION
Issues with v26:

* A lot of problems with CI
* StrictMode kills the app because Mixpanel isn't compatible (sockets have to be tagged)
* Cannot start a service from `application.onCreate()` anymore (because it's not considered "in the foreground" yet)
* Requires to upgrade to FCM to get notification, otherwise you get a message about "EnhancedIntentService" being unable to bind (probably again because services are not supposed to work in the background... but what do you do when you get a notification and you don't want to rebuild all your app?)

For now I consider v26 unusable and non-developer friendly.