### PR TITLE
Destructive actions should ask for confirmation

### DIFF
--- a/app/src/main/java/fr/neamar/lolgamedata/holder/AccountHolder.java
+++ b/app/src/main/java/fr/neamar/lolgamedata/holder/AccountHolder.java
@@ -1,6 +1,8 @@
 package fr.neamar.lolgamedata.holder;
 
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
@@ -51,11 +53,23 @@ public class AccountHolder extends RecyclerView.ViewHolder implements View.OnCli
     }
 
     @Override
-    public boolean onLongClick(View v) {
-        AccountManager accountManager = new AccountManager(v.getContext());
-        accountManager.removeAccount(account);
+    public boolean onLongClick(final View v) {
+        new AlertDialog.Builder(v.getContext())
+                .setTitle(R.string.dialog_account_title)
+                .setMessage((R.string.dialog_account_message))
+                .setPositiveButton(R.string.dialog_remove, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        AccountManager accountManager = new AccountManager(v.getContext());
+                        accountManager.removeAccount(account);
 
-        Toast.makeText(v.getContext(), R.string.account_removed, Toast.LENGTH_SHORT).show();
+                        Toast.makeText(v.getContext(), R.string.account_removed, Toast.LENGTH_SHORT).show();
+                    }
+                }).setNegativeButton(R.string.dialog_cancel, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        }).show();
+
         return true;
     }
 }

--- a/app/src/main/res/layout/fragment_drawer.xml
+++ b/app/src/main/res/layout/fragment_drawer.xml
@@ -18,9 +18,11 @@
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/view"
+        android:layout_above="@+id/remove_hint"
         android:layout_below="@+id/imageView2"
         tools:listitem="@layout/item_account" />
+
+
 
     <View
         android:id="@+id/view"
@@ -29,7 +31,17 @@
         android:layout_above="@+id/addLayout"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:background="#f6f6f6" />
+        android:background="#f6f6f6"/>
+
+    <TextView
+            android:id="@+id/remove_hint"
+            android:textColor="@color/textHint"
+            android:textSize="9sp"
+            android:text="@string/remove_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:layout_above="@id/view"/>
 
     <LinearLayout
         android:id="@+id/addLayout"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
     <color name="colorAd">#FF0000</color>
+    <color name="textHint">#22000000</color>
     <color name="colorAp">#7D26CD</color>
 
     <color name="colorGoodMatchup">#388E3C</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,4 +218,11 @@
     <string name="display_level">Always display champion level</string>
     <string name="display_level_summary">Display champion level even when player is ranked</string>
     <string name="overcharge">Overcharge</string>
+    <string name="dialog_account_title">Remove Account</string>
+    <string name="dialog_account_message">This action will remove your account. Are you sure you
+        want to continue?
+    </string>
+    <string name="dialog_remove">Remove</string>
+    <string name="dialog_cancel">Cancel</string>
+    <string name="remove_hint">(Long press to remove accounts)</string>
 </resources>


### PR DESCRIPTION
Context: Destructive actions like delete, remove etc should always ask for confirmation to prevent accidental behaviors. Since the remove account is not hinted anywhere in the application, the user has no information on what will happen if he long presses an account (which is commonly associated with "More actions"). In the mist of this situation, I've added:

- Added dialog on long press action
- Added a small tooltip at the bottom of the navigation bar informing the user about this action