### PR TITLE
Fix for Spinner objects getting clipped in a Dialog in Android P

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
         android:resizeableActivity="true"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:targetApi="P">
+        tools:targetApi="P"
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <uses-library
             android:name="org.apache.http.legacy"
             android:required="false" />

--- a/app/src/main/res/layout/activity_add_account.xml
+++ b/app/src/main/res/layout/activity_add_account.xml
@@ -24,6 +24,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
+        android:spinnerMode="dialog"
+        android:prompt="@string/pick_region"
         android:layout_margin="@dimen/dialog_margin"
         android:entries="@array/regions" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,4 +239,5 @@
     <string name="opponent">Opponent</string>
     <string name="what_is_this">What is this?</string>
     <string name="clash">Clash</string>
+    <string name="pick_region">Pick a Riot region</string>
 </resources>


### PR DESCRIPTION
Since Android P, a change in the API seems to prevent dropdown spinners from overflowing a dialog box.

Before Android P:
![image](https://user-images.githubusercontent.com/536844/50562363-9f51f900-0d13-11e9-988a-759f7f9bc980.png)

After Android P:
![2018-12-31 15 37 05](https://user-images.githubusercontent.com/536844/50562407-fb1c8200-0d13-11e9-94a8-c92a56cde519.png)

This pull request replaces the dropdown with a full dialog, which seems to work in all versions of Android.

New UI:

![2018-12-31 15 47 07](https://user-images.githubusercontent.com/536844/50562408-fbb51880-0d13-11e9-8df9-8c3fd89a51bd.png)
